### PR TITLE
Upgraded to detect 7

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,9 +9,9 @@ if (IS_WINDOWS) {
     returnCode = shell.exec(`powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect.ps1?$(Get-Random) | iex; detect ${detectArgs}"`).code;
   } else {
     // On everything else do bash
-    shell.exec("wget https://detect.synopsys.com/detect.sh")
-    shell.exec("chmod +x detect.sh")
-    returnCode = shell.exec(`./detect.sh ${detectArgs}`).code;
+    shell.exec("wget https://detect.synopsys.com/detect7.sh")
+    shell.exec("chmod +x detect7.sh")
+    returnCode = shell.exec(`./detect7.sh ${detectArgs}`).code;
 }
 
 if (returnCode == 3) {


### PR DESCRIPTION
After upgrading gradle version, builds break because of an incompatible API being used in detect 6.9.1.

The same has been fixed in detect 7. Upgraded the gradle action to use detect7